### PR TITLE
Use err.statusCode as fallback if defined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,8 @@ module.exports.handleErrors = function (fn, dump = false) {
       let status = res.statusCode || 500
       if (err.isBoom) {
         status = err.output.statusCode
+      } else if (err.statusCode) {
+        status = err.statusCode
       }
 
       // Since it's an error, it's safe to assume <400


### PR DESCRIPTION
Micro framework's own createError function sets the statusCode
property on the Error object directly.

This change allows the handler to properly catch errors
e.g. from middleware where the micro createError is used
instead of micro-boom createError.